### PR TITLE
feat: support using natural jasmine syntax when comp is not found

### DIFF
--- a/src/app/public/src/component-selector.spec.ts
+++ b/src/app/public/src/component-selector.spec.ts
@@ -49,12 +49,12 @@ describe('Component selector', () => {
     });
   });
 
-  it('should throw an error if no element is found with the specified ID', () => {
+  it('should return undefined if no element is found with the specified ID', () => {
     const fixture = TestBed.createComponent(TestComponent);
 
     expect(
-      () => SkyTestComponentSelector.selectAvatar(fixture, 'asdf')
-    ).toThrowError('No element was found with a test ID of "asdf".');
+      SkyTestComponentSelector.selectAvatar(fixture, 'asdf')
+    ).toBeUndefined();
   });
 
   it('should throw an error if the specified element is not of the expected type', () => {

--- a/src/app/public/src/component-selector.ts
+++ b/src/app/public/src/component-selector.ts
@@ -1,4 +1,8 @@
 import {
+  Type
+} from '@angular/core';
+
+import {
   ComponentFixture
 } from '@angular/core/testing';
 
@@ -28,17 +32,23 @@ function getEl(
     By.css(`[data-sky-id="${skyTestId}"]`)
   );
 
-  if (!skyEl) {
-    throw new Error(`No element was found with a test ID of "${skyTestId}".`);
-  }
-
-  if (skyEl.name !== elType) {
+  if (skyEl && skyEl.name !== elType) {
     throw new Error(
       `The element with the test ID "${skyTestId}" is not a component of type ${elType}."`
     );
   }
 
   return skyEl;
+}
+
+function getFixture<T>(
+  c: Type<T>,
+  fixture: ComponentFixture<any>,
+  skyTestId: string,
+  elType: string
+): T {
+  const el = getEl(fixture, skyTestId, elType);
+  return (el) ? new c(el) : undefined;
 }
 
 /**
@@ -56,7 +66,7 @@ export namespace SkyTestComponentSelector {
     fixture: ComponentFixture<any>,
     skyTestId: string
   ): SkyActionButtonFixture {
-    return new SkyActionButtonFixture(getEl(fixture, skyTestId, 'sky-action-button'));
+    return getFixture(SkyActionButtonFixture, fixture, skyTestId, 'sky-action-button');
   }
 
   /**
@@ -68,7 +78,7 @@ export namespace SkyTestComponentSelector {
     fixture: ComponentFixture<any>,
     skyTestId: string
   ): SkyAlertFixture {
-    return new SkyAlertFixture(getEl(fixture, skyTestId, 'sky-alert'));
+    return getFixture(SkyAlertFixture, fixture, skyTestId, 'sky-alert');
   }
 
   /**
@@ -80,7 +90,7 @@ export namespace SkyTestComponentSelector {
     fixture: ComponentFixture<any>,
     skyTestId: string
   ): SkyAvatarFixture {
-    return new SkyAvatarFixture(getEl(fixture, skyTestId, 'sky-avatar'));
+    return getFixture(SkyAvatarFixture, fixture, skyTestId, 'sky-avatar');
   }
 
   /**
@@ -92,7 +102,7 @@ export namespace SkyTestComponentSelector {
     fixture: ComponentFixture<any>,
     skyTestId: string
   ): SkyCardFixture {
-    return new SkyCardFixture(getEl(fixture, skyTestId, 'sky-card'));
+    return getFixture(SkyCardFixture, fixture, skyTestId, 'sky-card');
   }
 
   /**
@@ -104,7 +114,7 @@ export namespace SkyTestComponentSelector {
     fixture: ComponentFixture<any>,
     skyTestId: string
   ): SkyErrorFixture {
-    return new SkyErrorFixture(getEl(fixture, skyTestId, 'sky-error'));
+    return getFixture(SkyErrorFixture, fixture, skyTestId, 'sky-error');
   }
 
   /**
@@ -116,7 +126,7 @@ export namespace SkyTestComponentSelector {
     fixture: ComponentFixture<any>,
     skyTestId: string
   ): SkyLabelFixture {
-    return new SkyLabelFixture(getEl(fixture, skyTestId, 'sky-label'));
+    return getFixture(SkyLabelFixture, fixture, skyTestId, 'sky-label');
   }
 
   /**
@@ -128,7 +138,7 @@ export namespace SkyTestComponentSelector {
     fixture: ComponentFixture<any>,
     skyTestId: string
   ): SkyListViewChecklistFixture {
-    return new SkyListViewChecklistFixture(getEl(fixture, skyTestId, 'sky-list-view-checklist'));
+    return getFixture(SkyListViewChecklistFixture, fixture, skyTestId, 'sky-list-view-checklist');
   }
 
   /**
@@ -140,7 +150,7 @@ export namespace SkyTestComponentSelector {
     fixture: ComponentFixture<any>,
     skyTestId: string
   ): SkyListViewGridFixture {
-    return new SkyListViewGridFixture(getEl(fixture, skyTestId, 'sky-list-view-grid'));
+    return getFixture(SkyListViewGridFixture, fixture, skyTestId, 'sky-list-view-grid');
   }
 
   /**
@@ -152,7 +162,7 @@ export namespace SkyTestComponentSelector {
     fixture: ComponentFixture<any>,
     skyTestId: string
   ): SkyPageSummaryFixture {
-    return new SkyPageSummaryFixture(getEl(fixture, skyTestId, 'sky-page-summary'));
+    return getFixture(SkyPageSummaryFixture, fixture, skyTestId, 'sky-page-summary');
   }
 
   /**
@@ -164,7 +174,7 @@ export namespace SkyTestComponentSelector {
     fixture: ComponentFixture<any>,
     skyTestId: string
   ): SkySearchFixture {
-    return new SkySearchFixture(getEl(fixture, skyTestId, 'sky-search'));
+    return getFixture(SkySearchFixture, fixture, skyTestId, 'sky-search');
   }
 
 }


### PR DESCRIPTION
Take the following case.

```html
<sky-alert *ngIf=someBool></sky-alert>
```

if you want to write a test for the scenario when the `sky-alert` should _not_ show up in the DOM, the previous strategy meant you had to write a test like such.

```typescript
expect(() => SkyTestComponentSelector.selectAlert(fixture, 'myId')).toThrowError();
```

this doesn't read very well. the case you're trying to test doesn't relate to errors, yet the way you have to write your assertion involves knowing about an error getting thrown. a more preferred way to assert this would be the following:

```typescript
expect(SkyTestComponentSelector.selectAlert(fixture, 'myId').not.toExist();
```

this reads more explicitly as to what you're trying to assert in the test.

this PR restructures the component selector in order to allow for this type of assertion by returning `undefined` in the scenario where the component isn't found. this mimics how you would do assertions for regular DOM elements (i.e. `expect(fixture.query('h1')).not.toExist())`) in similar scenarios.

the downside is that the way i've written this, i'm pretty sure it would be a breaking change. so if there are any ideas as to how to move to the new behavior in a non-breaking fashion, i'm all ears. i was a bit stumped on that point.